### PR TITLE
Adding CacheBootloader to the DEPENDENCIES

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,9 @@
 name: run-tests
 
 on:
+  pull_request: null
   push:
-    branches: [ 2.0 ]
-  pull_request:
-    branches: [ 2.0 ]
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,10 +1,9 @@
 name: run-tests
 
 on:
+  pull_request: null
   push:
-    branches: [ 2.0 ]
-  pull_request:
-    branches: [ 2.0 ]
+    branches: [ master ]
 
 jobs:
   static-analysis:

--- a/src/Bootloader/SchedulerBootloader.php
+++ b/src/Bootloader/SchedulerBootloader.php
@@ -9,6 +9,7 @@ use Spiral\Attributes\AttributeReader;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Boot\EnvironmentInterface;
+use Spiral\Cache\Bootloader\CacheBootloader;
 use Spiral\Cache\CacheStorageProviderInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Console\Bootloader\ConsoleBootloader;
@@ -36,6 +37,7 @@ class SchedulerBootloader extends Bootloader
     protected const DEPENDENCIES = [
         ConsoleBootloader::class,
         TokenizerBootloader::class,
+        CacheBootloader::class,
     ];
 
     protected const SINGLETONS = [

--- a/tests/src/Config/SchedulerConfigTest.php
+++ b/tests/src/Config/SchedulerConfigTest.php
@@ -15,14 +15,22 @@ final class SchedulerConfigTest extends TestCase
             'timezone' => 'UTC'
         ]);
 
-
         $this->assertSame('UTC', $config->getTimezone()->getName());
     }
 
     public function testGetsTimezoneCanReturnNull(): void
     {
-        $config = new SchedulerConfig();
+        $config = new SchedulerConfig([
+            'timezone' => null
+        ]);
         $this->assertNull($config->getTimezone());
+    }
+
+    public function testGetsDefaultTimezone(): void
+    {
+        $config = new SchedulerConfig();
+
+        $this->assertSame('UTC', $config->getTimezone()->getName());
     }
 
     public function testGetsCacheStorage(): void


### PR DESCRIPTION
If we don't manually add **Spiral\Cache\Bootloader\CacheBootloader**, an error has occurred:

```bash
[Spiral\Core\Exception\Container\NotFoundException]                                                                             
 Can't resolve `Spiral\Scheduler\JobsLocatorInterface`: undefined class or binding `Spiral\Cache\CacheStorageProviderInterface`.
 Container trace list:
 - action: 'resolve from binding'
   alias: 'Spiral\Scheduler\JobsLocatorInterface'
   context: 'locator'
   binding: [
     0: 'Spiral\Scheduler\JobsLocator',
     1: true
   ]
   - action: 'resolve from binding'
     alias: 'Spiral\Scheduler\JobsLocator'
     context: 'locator'
     binding: [
       0: [
         0: 'Spiral\Scheduler\Bootloader\SchedulerBootloader',
         1: 'initJobsLocator'
       ],
       1: true
     ]
     - action: 'resolve from binding'
       alias: 'Spiral\Scheduler\Mutex\JobMutexInterface'
       context: 'mutex'
       binding: [
         0: [
           0: 'Spiral\Scheduler\Bootloader\SchedulerBootloader',
           1: 'initEventMutex'
         ],
         1: true
       ]
       - action: 'autowire'
         alias: 'Spiral\Cache\CacheStorageProviderInterface'
         context: 'provider'

```