### PR TITLE
display "No scheduled jobs are ready to run." only in verbose mode

### DIFF
--- a/src/Commands/ScheduleRunCommand.php
+++ b/src/Commands/ScheduleRunCommand.php
@@ -41,7 +41,7 @@ final class ScheduleRunCommand extends Command
             $jobsRan = true;
         }
 
-        if (! $jobsRan) {
+        if (! $jobsRan && $this->isVerbose()) {
             $this->info('No scheduled jobs are ready to run.');
         }
 


### PR DESCRIPTION
Now I have to many logs garbage

![image](https://github.com/user-attachments/assets/e3f3514f-8819-4ff3-bb9a-a1efc31c12e6)
