### PR TITLE
schedule:run remove log date

### DIFF
--- a/src/Commands/ScheduleRunCommand.php
+++ b/src/Commands/ScheduleRunCommand.php
@@ -31,8 +31,7 @@ final class ScheduleRunCommand extends Command
 
             $this->info(
                 \sprintf(
-                    '[%s] Running scheduled: `%s`',
-                    \date('c'),
+                    'Running scheduled: `%s`',
                     $job->getDescription() ?? $job->getSystemDescription(),
                 ),
             );


### PR DESCRIPTION
As it run within `rr services` the running log already has time.
The date in the console output makes filtering by similar logs impossible.

<img width="1400" height="81" alt="image" src="https://github.com/user-attachments/assets/57e7d8c9-3f9a-4364-9d62-29cb6909e108" />
